### PR TITLE
identify state machine nodes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,7 @@
 {
     "version": "0.2.0",
     "configurations": [
+        
         {
             "name": "Extension",
             "type": "extensionHost",

--- a/src/cdk/explorer/getCfnDefinition.ts
+++ b/src/cdk/explorer/getCfnDefinition.ts
@@ -1,0 +1,46 @@
+import * as fs from 'fs';
+
+/**
+ * @param uniqueIdentifier unique identifier of state machine
+ * @param cdkOutPath cdk.out path
+ * @param stackName name of root stack of the project
+ */
+export function getCfnDefinitionForStateMachine(uniqueIdentifier: string, cdkOutPath: string, stackName: string) {
+
+    try {
+        console.log(cdkOutPath)
+        var data = fs.readFileSync(cdkOutPath + `/${stackName}.template.json`, 'utf8');
+        var jsonObj = JSON.parse(data)
+        jsonObj = jsonObj.Resources[`${uniqueIdentifier}`].Properties.DefinitionString["Fn::Join"][1]
+        data = JSON.stringify(jsonObj)
+        data = escape(data)
+
+        return data
+    }
+    catch (e) {
+
+    }
+
+}
+
+function escape(str: string) {
+    if (typeof (str) != "string") return str;
+
+    var str1 = '{"Ref":'
+    var re1 = new RegExp(str1, 'g');
+    var str2 = '},""'
+    var re2 = new RegExp(str2, 'g')
+    return str
+        .trim()
+        .substring(1)
+        .slice(0, -1)
+        .trim()
+        .substring(1)
+        .slice(0, -1)
+        .replace(/\"\",/g, '')
+        .replace(/\"\"/g, '')
+        .replace(/\\/g, '')
+        .replace(re1, '')
+        .replace(re2, '')
+        ;
+};

--- a/src/cdk/explorer/nodes/constructNode.ts
+++ b/src/cdk/explorer/nodes/constructNode.ts
@@ -66,7 +66,8 @@ export class ConstructNode extends AWSTreeNodeBase {
                 entities.push(
                     new ConstructNode(
                         this,
-                        treeInspector.getDisplayLabel(child),
+                        //treeInspector.getDisplayLabel(child),
+                        treeInspector.isStateMachine(child)?treeInspector.getDisplayLabel(child)+` Visualize!` :treeInspector.getDisplayLabel(child),
                         child.children || child.attributes
                             ? vscode.TreeItemCollapsibleState.Collapsed
                             : vscode.TreeItemCollapsibleState.None,

--- a/src/cdk/explorer/nodes/constructNode.ts
+++ b/src/cdk/explorer/nodes/constructNode.ts
@@ -66,8 +66,7 @@ export class ConstructNode extends AWSTreeNodeBase {
                 entities.push(
                     new ConstructNode(
                         this,
-                        //treeInspector.getDisplayLabel(child),
-                        treeInspector.isStateMachine(child)?treeInspector.getDisplayLabel(child)+` Visualize!` :treeInspector.getDisplayLabel(child),
+                        treeInspector.getDisplayLabel(child),
                         child.children || child.attributes
                             ? vscode.TreeItemCollapsibleState.Collapsed
                             : vscode.TreeItemCollapsibleState.None,

--- a/src/cdk/explorer/tree/treeInspector.ts
+++ b/src/cdk/explorer/tree/treeInspector.ts
@@ -73,9 +73,5 @@ export function getDisplayLabel(construct: ConstructTreeEntity): string {
 export function isStateMachine(construct: ConstructTreeEntity): boolean{
     const type: string = getTypeAttributeOrDefault(construct, '')
 
-    if (construct.id === 'Resource' && type==='AWS::StepFunctions::StateMachine') {
-        return true
-    }
-    
-    return false
+    return construct.id === 'Resource' && type === 'AWS::StepFunctions::StateMachine'
 }

--- a/src/cdk/explorer/tree/treeInspector.ts
+++ b/src/cdk/explorer/tree/treeInspector.ts
@@ -65,11 +65,6 @@ export function getDisplayLabel(construct: ConstructTreeEntity): string {
 }
 
 
-/** 
-* (for CDK Visualization) Determines if a construct is a Resource and a state machine
-*
-* @param construct CDK construct
-*/
 export function isStateMachine(construct: ConstructTreeEntity): boolean{
     const type: string = getTypeAttributeOrDefault(construct, '')
 

--- a/src/cdk/explorer/tree/treeInspector.ts
+++ b/src/cdk/explorer/tree/treeInspector.ts
@@ -65,8 +65,17 @@ export function getDisplayLabel(construct: ConstructTreeEntity): string {
 }
 
 
+/** 
+* @param construct CDK construct
+*/
 export function isStateMachine(construct: ConstructTreeEntity): boolean{
-    const type: string = getTypeAttributeOrDefault(construct, '')
 
-    return construct.id === 'Resource' && type === 'AWS::StepFunctions::StateMachine'
+    if(construct.children){
+        const resource = construct.children["Resource"]   
+        if(!resource) return false
+        
+        const type: string = getTypeAttributeOrDefault(resource, '')
+        if(type && type === 'AWS::StepFunctions::StateMachine') return true
+    }
+    return false
 }

--- a/src/cdk/explorer/tree/treeInspector.ts
+++ b/src/cdk/explorer/tree/treeInspector.ts
@@ -63,3 +63,19 @@ export function getDisplayLabel(construct: ConstructTreeEntity): string {
 
     return construct.id
 }
+
+
+/** 
+* (for CDK Visualization) Determines if a construct is a Resource and a state machine
+*
+* @param construct CDK construct
+*/
+export function isStateMachine(construct: ConstructTreeEntity): boolean{
+    const type: string = getTypeAttributeOrDefault(construct, '')
+
+    if (construct.id === 'Resource' && type==='AWS::StepFunctions::StateMachine') {
+        return true
+    }
+    
+    return false
+}

--- a/src/test/cdk/tree/treeInspector.test.ts
+++ b/src/test/cdk/tree/treeInspector.test.ts
@@ -117,47 +117,76 @@ describe('TreeInspector', function () {
     })
 
 
-    it('returns true when tree node is a resource and a state machine', async function () {
+    it('returns true when tree node contains a node with id === "Resource" and type === "StateMachine"', async function () {
         const construct: ConstructTreeEntity = {
-            id: 'Resource',
-            path: 'attributes',
-            attributes: {[CfnResourceKeys.TYPE]:'AWS::StepFunctions::StateMachine'},
+            id: 'StateMachine',
+            path: 'aws-stepfunctions-integ/StateMachine',
+            children: { 'Resource' : {
+                            id: 'Resource',
+                            path: 'aws-stepfunctions-integ/StateMachine/Resource',
+                            attributes: {
+                                "aws:cdk:cloudformation:type": 'AWS::StepFunctions::StateMachine'
+                            }
+                        }
+                      }
+
         }
 
         assert.ok(treeInspector.isStateMachine(construct))
     })
 
-    it('returns false when tree node is a resource and not state machine', async function () {
+    it('returns true when tree node contains a node with id !== "Resource" and type === "StateMachine"', async function () {
         const construct: ConstructTreeEntity = {
-            id: 'Resource',
-            path: 'attributes',
-            attributes: {[CfnResourceKeys.TYPE]:'AWS::StepFunctions::LambdaFunction'},
+            id: 'StateMachine',
+            path: 'aws-stepfunctions-integ/StateMachine',
+            children: { 'Other' : {
+                            id: 'Other',
+                            path: 'aws-stepfunctions-integ/StateMachine/Resource',
+                            attributes: {
+                                "aws:cdk:cloudformation:type": 'AWS::StepFunctions::StateMachine'
+                            }
+                        }
+                      }
+
         }
 
-        assert.strictEqual(treeInspector.isStateMachine(construct), false)
+        assert.strictEqual(treeInspector.isStateMachine(construct),false)
     })
 
-    
-    it('returns false when tree node is not a resource and is a state machine', async function () {
-        const construct: ConstructTreeEntity = {
-            id: 'no',
-            path: 'attributes',
-            attributes: {
-                [CfnResourceKeys.TYPE]:'AWS::StepFunctions::StateMachine'
-            },
-        }
+    it('returns false when tree node contains a node with id !== "Resource" and type !== "StateMachine"', async function () {
 
-        assert.strictEqual(treeInspector.isStateMachine(construct), false)
+        const construct: ConstructTreeEntity = {
+            id: 'StateMachine',
+            path: 'aws-stepfunctions-integ/LambdaFunction',
+            children: { 'Other' : {
+                            id: 'Other',
+                            path: 'aws-stepfunctions-integ/LambdaFunction/Resource',
+                            attributes: {
+                                "aws:cdk:cloudformation:type": 'AWS::StepFunctions::LambdaFunction'
+                            }
+                        }
+                      }
+
+        }
+        assert.strictEqual(treeInspector.isStateMachine(construct),false)
     })
 
 
-    it('returns false when tree node is not a resource and not a state machine', async function () {
-        const construct: ConstructTreeEntity = {
-            id: 'no',
-            path: 'attributes',
-            attributes: {[CfnResourceKeys.TYPE]:'AWS::StepFunctions::LambdaFunction'},
-        }
+    it('returns false when tree node contains a node with id === "Resource" and type !== "StateMachine"', async function () {
 
-        assert.strictEqual(treeInspector.isStateMachine(construct), false)
+        const construct: ConstructTreeEntity = {
+            id: 'StateMachine',
+            path: 'aws-stepfunctions-integ/LambdaFunction',
+            children: { 'Resource' : {
+                            id: 'Resource',
+                            path: 'aws-stepfunctions-integ/LambdaFunction/Resource',
+                            attributes: {
+                                "aws:cdk:cloudformation:type": 'AWS::StepFunctions::LambdaFunction'
+                            }
+                        }
+                      }
+
+        }
+        assert.strictEqual(treeInspector.isStateMachine(construct),false)
     })
 })

--- a/src/test/cdk/tree/treeInspector.test.ts
+++ b/src/test/cdk/tree/treeInspector.test.ts
@@ -115,4 +115,47 @@ describe('TreeInspector', function () {
 
         assert.strictEqual(props, undefined)
     })
+
+
+    it('returns true when tree node is a resource and a state machine', async function () {
+        const construct: ConstructTreeEntity = {
+            id: 'Resource',
+            path: 'attributes',
+            attributes: {[CfnResourceKeys.TYPE]:'AWS::StepFunctions::StateMachine'},
+        }
+
+        assert.ok(treeInspector.isStateMachine(construct))
+    })
+
+    it('returns false when tree node is a resource and not state machine', async function () {
+        const construct: ConstructTreeEntity = {
+            id: 'Resource',
+            path: 'attributes',
+            attributes: {[CfnResourceKeys.TYPE]:'AWS::StepFunctions::LambdaFunction'},
+        }
+
+        assert.strictEqual(treeInspector.isStateMachine(construct),false)
+    })
+
+    
+    it('returns false when tree node is not a resource and is a state machine', async function () {
+        const construct: ConstructTreeEntity = {
+            id: 'no',
+            path: 'attributes',
+            attributes: {[CfnResourceKeys.TYPE]:'AWS::StepFunctions::StateMachine'},
+        }
+
+        assert.strictEqual(treeInspector.isStateMachine(construct),false)
+    })
+
+
+    it('returns false when tree node is not a resource and not a state machine', async function () {
+        const construct: ConstructTreeEntity = {
+            id: 'no',
+            path: 'attributes',
+            attributes: {[CfnResourceKeys.TYPE]:'AWS::StepFunctions::LambdaFunction'},
+        }
+
+        assert.strictEqual(treeInspector.isStateMachine(construct),false)
+    })
 })

--- a/src/test/cdk/tree/treeInspector.test.ts
+++ b/src/test/cdk/tree/treeInspector.test.ts
@@ -121,7 +121,7 @@ describe('TreeInspector', function () {
         const construct: ConstructTreeEntity = {
             id: 'StateMachine',
             path: 'aws-stepfunctions-integ/StateMachine',
-            children: { 'Resource' : {
+            children: { 'Resource': {
                             id: 'Resource',
                             path: 'aws-stepfunctions-integ/StateMachine/Resource',
                             attributes: {
@@ -139,7 +139,7 @@ describe('TreeInspector', function () {
         const construct: ConstructTreeEntity = {
             id: 'StateMachine',
             path: 'aws-stepfunctions-integ/StateMachine',
-            children: { 'Other' : {
+            children: { 'Other': {
                             id: 'Other',
                             path: 'aws-stepfunctions-integ/StateMachine/Resource',
                             attributes: {
@@ -158,7 +158,7 @@ describe('TreeInspector', function () {
         const construct: ConstructTreeEntity = {
             id: 'StateMachine',
             path: 'aws-stepfunctions-integ/LambdaFunction',
-            children: { 'Other' : {
+            children: { 'Other': {
                             id: 'Other',
                             path: 'aws-stepfunctions-integ/LambdaFunction/Resource',
                             attributes: {
@@ -177,7 +177,7 @@ describe('TreeInspector', function () {
         const construct: ConstructTreeEntity = {
             id: 'StateMachine',
             path: 'aws-stepfunctions-integ/LambdaFunction',
-            children: { 'Resource' : {
+            children: { 'Resource': {
                             id: 'Resource',
                             path: 'aws-stepfunctions-integ/LambdaFunction/Resource',
                             attributes: {

--- a/src/test/cdk/tree/treeInspector.test.ts
+++ b/src/test/cdk/tree/treeInspector.test.ts
@@ -134,7 +134,7 @@ describe('TreeInspector', function () {
             attributes: {[CfnResourceKeys.TYPE]:'AWS::StepFunctions::LambdaFunction'},
         }
 
-        assert.strictEqual(treeInspector.isStateMachine(construct),false)
+        assert.strictEqual(treeInspector.isStateMachine(construct), false)
     })
 
     
@@ -142,10 +142,12 @@ describe('TreeInspector', function () {
         const construct: ConstructTreeEntity = {
             id: 'no',
             path: 'attributes',
-            attributes: {[CfnResourceKeys.TYPE]:'AWS::StepFunctions::StateMachine'},
+            attributes: {
+                [CfnResourceKeys.TYPE]:'AWS::StepFunctions::StateMachine'
+            },
         }
 
-        assert.strictEqual(treeInspector.isStateMachine(construct),false)
+        assert.strictEqual(treeInspector.isStateMachine(construct), false)
     })
 
 
@@ -156,6 +158,6 @@ describe('TreeInspector', function () {
             attributes: {[CfnResourceKeys.TYPE]:'AWS::StepFunctions::LambdaFunction'},
         }
 
-        assert.strictEqual(treeInspector.isStateMachine(construct),false)
+        assert.strictEqual(treeInspector.isStateMachine(construct), false)
     })
 })


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

# Description of changes

In order to offer visualization capabilities in the CDK Explorer tree, I made changes to the code so that it can identify which nodes in the tree are state machines. 
The changes include:
- function isStateMachine(construct: ConstructTreeEntity) that identifies  whether a given input is a state machine or not
- Placeholder for the visualization button ('Visualization!' text) next to state machine nodes in the tree
- Unit tests for this functionality 

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
